### PR TITLE
Add createOutDir utility and use in processManager

### DIFF
--- a/server/utils/createOutDir.js
+++ b/server/utils/createOutDir.js
@@ -1,0 +1,14 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default async function createOutDir(dirPath) {
+    // dirPath is relative to server/ directory
+    const outputDir = path.join(__dirname, '..', dirPath);
+    if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+    }
+}

--- a/server/utils/processManager.js
+++ b/server/utils/processManager.js
@@ -1,10 +1,12 @@
 import mergeSettings from "./mergeSettings.js";
+import createOutDir from "./createOutDir.js";
 
 // Process Manager for the Pseudonymization process
 export default async function startProcessManager(sessionId, data)
 {
     //console.log(data);
     //console.log(sessionId);
+    createOutDir("output");
     await mergeSettings(sessionId, data, "json");
     await mergeSettings(sessionId, data, "xml");
 }


### PR DESCRIPTION
Introduces createOutDir.js to ensure output directory exists before processing. Updates processManager to call createOutDir for the 'output' directory prior to merging settings.

Contributes to #1 